### PR TITLE
Updated _config.yml to fix highlighter warning

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -11,7 +11,7 @@ github_username:  github_username
 # Build settings
 markdown: kramdown
 
-highlighter: pygments
+highlighter: rouge
 
 # Pagination
 paginate: 15


### PR DESCRIPTION
GitHub Pages does not support pygments highlighter. Warning message...

To suppress this warning, change the 'highlighter' value to 'rouge' in your '_config.yml' and ensure the 'pygments' key is unset. For more information, see https://help.github.com/articles/page-build-failed-config-file-error/#fixing-highlighting-errors.
