### PR TITLE
Fix footer height and wrapping

### DIFF
--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -84,6 +84,11 @@ left:0px;
 bottom:0px;
 width:100%;
 }
+
+.site-footer p {
+    margin-bottom: 0; // Remove margin set in _sass/_base.scss for vertical rythm
+}
+
 /**
  * Pagination   **********************************************************
  */

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -82,7 +82,6 @@ color: #aaa;
 position:fixed;
 left:0px;
 bottom:0px;
-height:25px;
 width:100%;
 }
 /**


### PR DESCRIPTION
Fixes #17 

Remove the footer's fixed height and reset the default `<p>` bottom margin (set in `_base.scss`) to remove the unwanted space below the footer text.

Tested locally, it works 🚀